### PR TITLE
Add previousNonWhitespaceSibling method

### DIFF
--- a/src/voku/helper/SimpleHtmlDom.php
+++ b/src/voku/helper/SimpleHtmlDom.php
@@ -684,6 +684,29 @@ class SimpleHtmlDom extends AbstractSimpleHtmlDom implements \IteratorAggregate,
         return new static($node);
     }
 
+
+    /**
+     * Returns the previous sibling of node.
+     *
+     * @return SimpleHtmlDomInterface|null
+     */
+    public function previousNonWhitespaceSibling()
+    {
+        /** @var \DOMNode|null $node */
+        $node = $this->node->previousSibling;
+
+        while ($node && !\trim($node->textContent)) {
+            /** @var \DOMNode|null $node */
+            $node = $node->previousSibling;
+        }
+
+        if ($node === null) {
+            return null;
+        }
+
+        return new static($node);
+    }
+
     /**
      * @param string|string[]|null $value <p>
      *                                    null === get the current input value

--- a/tests/HtmlDomParserTest.php
+++ b/tests/HtmlDomParserTest.php
@@ -1389,7 +1389,7 @@ h1 {
         );
     }
 
-    public function testInnerTextIssue()
+    public function testNextNonWhitespaceSibling()
     {
         $txt = <<<'___'
 <div class="detail J_tab" id="tab_show_1">
@@ -1439,6 +1439,60 @@ ___;
 
         $html_meal = HtmlDomParser::str_get_html($txt);
         $result = $html_meal->findOne('#tab_show_1 table')->nextNonWhitespaceSibling()->innertext;
+
+        static::assertSame($expected, $result);
+    }
+
+    public function testPreviousNonWhitespaceSibling()
+    {
+        $txt = <<<'___'
+<div class="detail J_tab" id="tab_show_1">
+    <h3 class="new-tit">
+        <span class="name">product detail</span>
+    </h3>
+    <div class="detail-tit"></div>
+    <div>
+        <p>
+            <b>[aaaaa]</b>
+        </p>
+        <p></p>
+        <div>bbbbbb</div>
+        <div>ccccccccccccccc</div>
+        <div>
+            <br>
+        </div>
+        <p></p>
+        <p>
+            <b>[ddddd]</b>
+        </p>
+    </div>
+    <table width="100%" cellpadding="0" cellspacing="0" class="detail-table">
+        <tbody>
+            <tr>
+                <td>aaaaa</td>
+                <td class="tc">bbbb</td>
+                <td class="tc">ccccc</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+___;
+        $expected = '<p>
+            <b>[aaaaa]</b>
+        </p>
+        <p></p>
+        <div>bbbbbb</div>
+        <div>ccccccccccccccc</div>
+        <div>
+            <br>
+        </div>
+        <p></p>
+        <p>
+            <b>[ddddd]</b>
+        </p>';
+
+        $html_meal = HtmlDomParser::str_get_html($txt);
+        $result = $html_meal->findOne('#tab_show_1 table')->previousNonWhitespaceSibling()->innertext;
 
         static::assertSame($expected, $result);
     }


### PR DESCRIPTION
The `nextNonWhitespaceSibling` exists, seems legit to have the same one for previous sibling node ;)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/simple_html_dom/67)
<!-- Reviewable:end -->
