### PR TITLE
Added getTag() and removeAttributes() and a test for both

### DIFF
--- a/src/voku/helper/SimpleHtmlDom.php
+++ b/src/voku/helper/SimpleHtmlDom.php
@@ -53,6 +53,11 @@ class SimpleHtmlDom extends AbstractSimpleHtmlDom implements \IteratorAggregate,
         return $this->getHtmlDomParser()->find($selector, $idx);
     }
 
+    public function getTag(): string
+    {
+        return $this->tag;
+    }
+
     /**
      * Returns an array of attributes.
      *
@@ -155,6 +160,21 @@ class SimpleHtmlDom extends AbstractSimpleHtmlDom implements \IteratorAggregate,
             $this->node->removeAttribute($name);
         }
 
+        return $this;
+    }
+
+    /**
+     * Remove all attributes
+     *
+     * @return SimpleHtmlDomInterface
+     */
+    public function removeAttributes(): SimpleHtmlDomInterface
+    {
+        if ($this->hasAttributes()) {
+            foreach ($this->getAllAttributes() as $key=>$value) {
+                $this->removeAttribute($key);
+            }
+        }
         return $this;
     }
 

--- a/src/voku/helper/SimpleHtmlDom.php
+++ b/src/voku/helper/SimpleHtmlDom.php
@@ -999,6 +999,6 @@ class SimpleHtmlDom extends AbstractSimpleHtmlDom implements \IteratorAggregate,
      */
     public function delete()
     {
-        $this->outertext="";
+        $this->outertext='';
     }
 }

--- a/src/voku/helper/SimpleHtmlDom.php
+++ b/src/voku/helper/SimpleHtmlDom.php
@@ -171,8 +171,8 @@ class SimpleHtmlDom extends AbstractSimpleHtmlDom implements \IteratorAggregate,
     public function removeAttributes(): SimpleHtmlDomInterface
     {
         if ($this->hasAttributes()) {
-            foreach ($this->getAllAttributes() as $key=>$value) {
-                $this->removeAttribute($key);
+            foreach (array_keys($this->getAllAttributes()) as $attribute) {
+                $this->removeAttribute($attribute);
             }
         }
         return $this;

--- a/src/voku/helper/SimpleHtmlDom.php
+++ b/src/voku/helper/SimpleHtmlDom.php
@@ -991,4 +991,14 @@ class SimpleHtmlDom extends AbstractSimpleHtmlDom implements \IteratorAggregate,
                 )
             );
     }
+
+    /**
+     * Delete
+     *
+     * @return void
+     */
+    public function delete()
+    {
+        $this->outertext="";
+    }
 }

--- a/src/voku/helper/SimpleHtmlDomBlank.php
+++ b/src/voku/helper/SimpleHtmlDomBlank.php
@@ -45,6 +45,11 @@ class SimpleHtmlDomBlank extends AbstractSimpleHtmlDom implements \IteratorAggre
         return new SimpleHtmlDomNodeBlank();
     }
 
+    public function getTag(): string
+    {
+        return "";
+    }
+
     /**
      * Returns an array of attributes.
      *
@@ -119,6 +124,16 @@ class SimpleHtmlDomBlank extends AbstractSimpleHtmlDom implements \IteratorAggre
      * @return SimpleHtmlDomInterface
      */
     public function removeAttribute(string $name): SimpleHtmlDomInterface
+    {
+        return $this;
+    }
+
+    /**
+     * Remove all attributes
+     *
+     * @return SimpleHtmlDomBlank
+     */
+    public function removeAttributes(): SimpleHtmlDomInterface
     {
         return $this;
     }

--- a/src/voku/helper/SimpleHtmlDomBlank.php
+++ b/src/voku/helper/SimpleHtmlDomBlank.php
@@ -457,4 +457,14 @@ class SimpleHtmlDomBlank extends AbstractSimpleHtmlDom implements \IteratorAggre
     {
         return '';
     }
+
+    /**
+     * Delete
+     *
+     * @return void
+     */
+    public function delete()
+    {
+        $this->outertext="";
+    }
 }

--- a/src/voku/helper/SimpleHtmlDomBlank.php
+++ b/src/voku/helper/SimpleHtmlDomBlank.php
@@ -47,7 +47,7 @@ class SimpleHtmlDomBlank extends AbstractSimpleHtmlDom implements \IteratorAggre
 
     public function getTag(): string
     {
-        return "";
+        return '';
     }
 
     /**
@@ -465,6 +465,6 @@ class SimpleHtmlDomBlank extends AbstractSimpleHtmlDom implements \IteratorAggre
      */
     public function delete()
     {
-        $this->outertext="";
+        $this->outertext='';
     }
 }

--- a/src/voku/helper/SimpleHtmlDomInterface.php
+++ b/src/voku/helper/SimpleHtmlDomInterface.php
@@ -378,4 +378,11 @@ interface SimpleHtmlDomInterface extends \IteratorAggregate
      * @return string|string[]|null
      */
     public function val($value = null);
+
+    /**
+     * Delete
+     *
+     * @return mixed
+     */
+    public function delete();
 }

--- a/src/voku/helper/SimpleHtmlDomInterface.php
+++ b/src/voku/helper/SimpleHtmlDomInterface.php
@@ -89,6 +89,13 @@ interface SimpleHtmlDomInterface extends \IteratorAggregate
     public function __toString();
 
     /**
+     * Return the tag of node
+     *
+     * @return string
+     */
+    public function getTag():string;
+
+    /**
      * Returns children of node.
      *
      * @param int $idx
@@ -347,6 +354,13 @@ interface SimpleHtmlDomInterface extends \IteratorAggregate
      * @return SimpleHtmlDomInterface
      */
     public function setAttribute(string $name, $value = null, bool $strictEmptyValueCheck = false): self;
+
+    /**
+     * Remove all attributes
+     *
+     * @return SimpleHtmlDomInterface
+     */
+    public function removeAttributes(): self;
 
     /**
      * Get dom node's plain text.

--- a/tests/AuxiliarFunctions.php
+++ b/tests/AuxiliarFunctions.php
@@ -17,4 +17,11 @@ class AuxiliarFunctions extends TestCase
         $parser= HtmlDomParser::str_get_html("<body><span id='hello' class='hello'>Hello</span></body>");
         static::assertSame("<span>Hello</span>", $parser->findOne("span")->removeAttributes()->outerHtml());
     }
+
+    public function removeUsingDelete()
+    {
+        $parser= HtmlDomParser::str_get_html("<body><span id='hello' class='hello'>Hello</span></body>");
+        $parser->findOne("span")->delete();
+        static::assertSame("<body></body>", $parser->outerHtml());
+    }
 }

--- a/tests/AuxiliarFunctions.php
+++ b/tests/AuxiliarFunctions.php
@@ -1,0 +1,20 @@
+<?php
+
+
+use PHPUnit\Framework\TestCase;
+use voku\helper\HtmlDomParser;
+
+class AuxiliarFunctions extends TestCase
+{
+    public function testGetTag()
+    {
+        $parser= HtmlDomParser::str_get_html("<body><span>Hello</span></body>");
+        static::assertSame("span", $parser->findOne("span")->getTag());
+    }
+
+    public function testRemoveAttributes()
+    {
+        $parser= HtmlDomParser::str_get_html("<body><span id='hello' class='hello'>Hello</span></body>");
+        static::assertSame("<span>Hello</span>", $parser->findOne("span")->removeAttributes()->outerHtml());
+    }
+}

--- a/tests/AuxiliarFunctions.php
+++ b/tests/AuxiliarFunctions.php
@@ -8,20 +8,20 @@ class AuxiliarFunctions extends TestCase
 {
     public function testGetTag()
     {
-        $parser= HtmlDomParser::str_get_html("<body><span>Hello</span></body>");
-        static::assertSame("span", $parser->findOne("span")->getTag());
+        $parser= HtmlDomParser::str_get_html('<body><span>Hello</span></body>');
+        static::assertSame('span', $parser->findOne('span')->getTag());
     }
 
     public function testRemoveAttributes()
     {
-        $parser= HtmlDomParser::str_get_html("<body><span id='hello' class='hello'>Hello</span></body>");
-        static::assertSame("<span>Hello</span>", $parser->findOne("span")->removeAttributes()->outerHtml());
+        $parser= HtmlDomParser::str_get_html('<body><span id=\'hello\' class=\'hello\'>Hello</span></body>');
+        static::assertSame('<span>Hello</span>', $parser->findOne("span")->removeAttributes()->outerHtml());
     }
 
     public function removeUsingDelete()
     {
         $parser= HtmlDomParser::str_get_html("<body><span id='hello' class='hello'>Hello</span></body>");
-        $parser->findOne("span")->delete();
-        static::assertSame("<body></body>", $parser->outerHtml());
+        $parser->findOne('span')->delete();
+        static::assertSame('<body></body>', $parser->outerHtml());
     }
 }

--- a/tests/AuxiliarFunctions.php
+++ b/tests/AuxiliarFunctions.php
@@ -15,7 +15,7 @@ class AuxiliarFunctions extends TestCase
     public function testRemoveAttributes()
     {
         $parser= HtmlDomParser::str_get_html('<body><span id=\'hello\' class=\'hello\'>Hello</span></body>');
-        static::assertSame('<span>Hello</span>', $parser->findOne("span")->removeAttributes()->outerHtml());
+        static::assertSame('<span>Hello</span>', $parser->findOne('span')->removeAttributes()->outerHtml());
     }
 
     public function removeUsingDelete()

--- a/tests/AuxiliarFunctionsTest.php
+++ b/tests/AuxiliarFunctionsTest.php
@@ -4,7 +4,7 @@
 use PHPUnit\Framework\TestCase;
 use voku\helper\HtmlDomParser;
 
-class AuxiliarFunctionsTest extends TestCase
+final class AuxiliarFunctionsTest extends TestCase
 {
     public function testGetTag()
     {
@@ -18,7 +18,7 @@ class AuxiliarFunctionsTest extends TestCase
         static::assertSame('<span>Hello</span>', $parser->findOne('span')->removeAttributes()->outerHtml());
     }
 
-    public function removeUsingDelete()
+    public function testRemoveUsingDelete()
     {
         $parser= HtmlDomParser::str_get_html("<body><span id='hello' class='hello'>Hello</span></body>");
         $parser->findOne('span')->delete();

--- a/tests/AuxiliarFunctionsTest.php
+++ b/tests/AuxiliarFunctionsTest.php
@@ -4,7 +4,7 @@
 use PHPUnit\Framework\TestCase;
 use voku\helper\HtmlDomParser;
 
-class AuxiliarFunctions extends TestCase
+class AuxiliarFunctionsTest extends TestCase
 {
     public function testGetTag()
     {


### PR DESCRIPTION
I think that in some cases is needed the name of the tag and sometimes psalm/phpstan/others prefer a method over a property for that. 
Sometimes you need remove all attributes. Instead a foreach each time the method "removeAttributes" is better

And I added a method delete() that serve as an alias of `$this->outertext="";`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/simple_html_dom/76)
<!-- Reviewable:end -->
