### PR TITLE
Replace deprecated string interpolation usage

### DIFF
--- a/src/voku/helper/SimpleHtmlDom.php
+++ b/src/voku/helper/SimpleHtmlDom.php
@@ -505,7 +505,7 @@ class SimpleHtmlDom extends AbstractSimpleHtmlDom implements \IteratorAggregate,
      */
     public function getElementByClass(string $class): SimpleHtmlDomNodeInterface
     {
-        return $this->findMulti(".${class}");
+        return $this->findMulti(".{$class}");
     }
 
     /**
@@ -517,7 +517,7 @@ class SimpleHtmlDom extends AbstractSimpleHtmlDom implements \IteratorAggregate,
      */
     public function getElementById(string $id): SimpleHtmlDomInterface
     {
-        return $this->findOne("#${id}");
+        return $this->findOne("#{$id}");
     }
 
     /**
@@ -552,7 +552,7 @@ class SimpleHtmlDom extends AbstractSimpleHtmlDom implements \IteratorAggregate,
      */
     public function getElementsById(string $id, $idx = null)
     {
-        return $this->find("#${id}", $idx);
+        return $this->find("#{$id}", $idx);
     }
 
     /**

--- a/src/voku/helper/SimpleXmlDom.php
+++ b/src/voku/helper/SimpleXmlDom.php
@@ -455,7 +455,7 @@ class SimpleXmlDom extends AbstractSimpleXmlDom implements \IteratorAggregate, S
      */
     public function getElementByClass(string $class): SimpleXmlDomNodeInterface
     {
-        return $this->findMulti(".${class}");
+        return $this->findMulti(".{$class}");
     }
 
     /**
@@ -467,7 +467,7 @@ class SimpleXmlDom extends AbstractSimpleXmlDom implements \IteratorAggregate, S
      */
     public function getElementById(string $id): SimpleXmlDomInterface
     {
-        return $this->findOne("#${id}");
+        return $this->findOne("#{$id}");
     }
 
     /**
@@ -502,7 +502,7 @@ class SimpleXmlDom extends AbstractSimpleXmlDom implements \IteratorAggregate, S
      */
     public function getElementsById(string $id, $idx = null)
     {
-        return $this->find("#${id}", $idx);
+        return $this->find("#{$id}", $idx);
     }
 
     /**

--- a/src/voku/helper/XmlDomParser.php
+++ b/src/voku/helper/XmlDomParser.php
@@ -389,7 +389,7 @@ class XmlDomParser extends AbstractDomParser
      */
     public function getElementByClass(string $class): SimpleXmlDomNodeInterface
     {
-        return $this->findMulti(".${class}");
+        return $this->findMulti(".{$class}");
     }
 
     /**
@@ -401,7 +401,7 @@ class XmlDomParser extends AbstractDomParser
      */
     public function getElementById(string $id): SimpleXmlDomInterface
     {
-        return $this->findOne("#${id}");
+        return $this->findOne("#{$id}");
     }
 
     /**
@@ -432,7 +432,7 @@ class XmlDomParser extends AbstractDomParser
      */
     public function getElementsById(string $id, $idx = null)
     {
-        return $this->find("#${id}", $idx);
+        return $this->find("#{$id}", $idx);
     }
 
     /**
@@ -526,7 +526,7 @@ class XmlDomParser extends AbstractDomParser
             &&
             !\file_exists($filePath)
         ) {
-            throw new \RuntimeException("File ${filePath} not found");
+            throw new \RuntimeException("File {$filePath} not found");
         }
 
         try {
@@ -536,11 +536,11 @@ class XmlDomParser extends AbstractDomParser
                 $html = \file_get_contents($filePath);
             }
         } catch (\Exception $e) {
-            throw new \RuntimeException("Could not load file ${filePath}");
+            throw new \RuntimeException("Could not load file {$filePath}");
         }
 
         if ($html === false) {
-            throw new \RuntimeException("Could not load file ${filePath}");
+            throw new \RuntimeException("Could not load file {$filePath}");
         }
 
         return $this->loadHtml($html, $libXMLExtraOptions);
@@ -603,7 +603,7 @@ class XmlDomParser extends AbstractDomParser
             &&
             !\file_exists($filePath)
         ) {
-            throw new \RuntimeException("File ${filePath} not found");
+            throw new \RuntimeException("File {$filePath} not found");
         }
 
         try {
@@ -613,11 +613,11 @@ class XmlDomParser extends AbstractDomParser
                 $xml = \file_get_contents($filePath);
             }
         } catch (\Exception $e) {
-            throw new \RuntimeException("Could not load file ${filePath}");
+            throw new \RuntimeException("Could not load file {$filePath}");
         }
 
         if ($xml === false) {
-            throw new \RuntimeException("Could not load file ${filePath}");
+            throw new \RuntimeException("Could not load file {$filePath}");
         }
 
         return $this->loadXml($xml, $libXMLExtraOptions);

--- a/tests/HTML5DOMDocumentTest.php
+++ b/tests/HTML5DOMDocumentTest.php
@@ -64,14 +64,14 @@ final class HTML5DOMDocumentTest extends PHPUnit\Framework\TestCase
         $text = '';
         $html = $dom->findOne('html');
         foreach ($html->classList->entries() as $class) {
-            $text .= "[${class}]";
+            $text .= "[{$class}]";
         }
         static::assertSame('', $text);
 
         $text = '';
         $body = $dom->findOne('body');
         foreach ($body->classList->entries() as $class) {
-            $text .= "[${class}]";
+            $text .= "[{$class}]";
         }
         static::assertSame('[a][b][c]', $text);
     }


### PR DESCRIPTION
This PR replaces the now deprecated (as of PHP 8.2) `${var}` usage in string interpolation by `{$var}`.
Note that this change is backwards compatible with previous versions of PHP.

```
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /usr/src/app/tests/HTML5DOMDocumentTest.php on line 67
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /usr/src/app/tests/HTML5DOMDocumentTest.php on line 74
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /usr/src/app/src/voku/helper/SimpleHtmlDom.php on line 508
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /usr/src/app/src/voku/helper/SimpleHtmlDom.php on line 520
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /usr/src/app/src/voku/helper/SimpleHtmlDom.php on line 555
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /usr/src/app/src/voku/helper/SimpleXmlDom.php on line 458
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /usr/src/app/src/voku/helper/SimpleXmlDom.php on line 470
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /usr/src/app/src/voku/helper/SimpleXmlDom.php on line 505
```

Reference: https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/simple_html_dom/90)
<!-- Reviewable:end -->
