### PR TITLE
Upgrade code to work in PHP8 or greater and/or Laravel 9 or greater

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,14 @@ jobs:
             7.3,
             7.4,
             8.0,
-            8.1
+            8.1,
+            8.2
         ]
         composer: [basic]
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@2.9.0
@@ -44,7 +45,7 @@ jobs:
         run: echo "::set-output name=directory::$(composer config cache-dir)"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.directory }}
           key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -88,7 +89,7 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           files: build/logs/clover.xml
-          
+
       - name: Archive logs artifacts
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ composer require voku/portable-utf8 # if you need e.g. UTF-8 fixed output
 ### Quick Start
 
 ```php
-use voku\helper\HtmlDomParser;
+use Voku\Helper\HtmlDomParser;
 
 require_once 'composer/autoload.php';
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0",
+        "php": "^8.0 || ^8.1 || ^8.2",
         "ext-dom": "*",
         "ext-libxml": "*",
         "ext-simplexml": "*",
@@ -37,7 +37,7 @@
     },
     "autoload": {
         "psr-4": {
-            "voku\\helper\\": "src/voku/helper/"
+            "Voku\\Helper\\": "src/voku/helper/"
         }
     },
     "autoload-dev": {

--- a/example/example_add_content.php
+++ b/example/example_add_content.php
@@ -1,6 +1,6 @@
 <?php
 
-use voku\helper\HtmlDomParser;
+use Voku\Helper\HtmlDomParser;
 
 require_once '../vendor/autoload.php';
 

--- a/example/example_advanced_selector.php
+++ b/example/example_advanced_selector.php
@@ -1,6 +1,6 @@
 <?php
 
-use voku\helper\HtmlDomParser;
+use Voku\Helper\HtmlDomParser;
 
 require_once '../vendor/autoload.php';
 

--- a/example/example_basic_selector.php
+++ b/example/example_basic_selector.php
@@ -1,6 +1,6 @@
 <?php
 
-use voku\helper\HtmlDomParser;
+use Voku\Helper\HtmlDomParser;
 
 require_once '../vendor/autoload.php';
 

--- a/example/example_extract_data_attribute.php
+++ b/example/example_extract_data_attribute.php
@@ -1,6 +1,6 @@
 <?php
 
-use voku\helper\HtmlDomParser;
+use Voku\Helper\HtmlDomParser;
 
 require_once '../vendor/autoload.php';
 

--- a/example/example_extract_html.php
+++ b/example/example_extract_html.php
@@ -2,4 +2,4 @@
 
 require_once '../vendor/autoload.php';
 
-echo voku\helper\HtmlDomParser::file_get_html('https://www.google.com/')->plaintext;
+echo Voku\Helper\HtmlDomParser::file_get_html('https://www.google.com/')->plaintext;

--- a/example/example_extract_meta_tags.php
+++ b/example/example_extract_meta_tags.php
@@ -1,6 +1,6 @@
 <?php
 
-use voku\helper\HtmlDomParser;
+use Voku\Helper\HtmlDomParser;
 
 require_once '../vendor/autoload.php';
 

--- a/example/example_find_image_if_exists.php
+++ b/example/example_find_image_if_exists.php
@@ -10,7 +10,7 @@ $html = '
 <p class="lall">foo</p>
 ';
 
-$document = new \voku\helper\HtmlDomParser($html);
+$document = new \Voku\Helper\HtmlDomParser($html);
 
 $imageOrFalse = $document->findOneOrFalse('#test');
 if ($imageOrFalse !== false) {
@@ -25,7 +25,7 @@ $html = '
 <p class="lall">foo</p>
 ';
 
-$document = new \voku\helper\HtmlDomParser($html);
+$document = new \Voku\Helper\HtmlDomParser($html);
 
 $imageOrFalse = $document->findOneOrFalse('#non_test');
 if ($imageOrFalse !== false) {
@@ -41,7 +41,7 @@ $html = '
 <img class="image_foo" src="lall2.png" alt="foo2">
 ';
 
-$document = new \voku\helper\HtmlDomParser($html);
+$document = new \Voku\Helper\HtmlDomParser($html);
 
 $imagesOrFalse = $document->findMultiOrFalse('.image_foo');
 if ($imagesOrFalse !== false) {

--- a/example/example_find_text.php
+++ b/example/example_find_text.php
@@ -1,20 +1,20 @@
 <?php
 
-use voku\helper\SimpleHtmlDomInterface;
-use voku\helper\SimpleHtmlDomNode;
-use voku\helper\SimpleHtmlDomNodeInterface;
+use Voku\Helper\SimpleHtmlDomInterface;
+use Voku\Helper\SimpleHtmlDomNode;
+use Voku\Helper\SimpleHtmlDomNodeInterface;
 
 require_once '../vendor/autoload.php';
 
 /**
- * @param \voku\helper\HtmlDomParser $dom
+ * @param \Voku\Helper\HtmlDomParser $dom
  * @param string                     $selector
  * @param string                     $keyword
  *
  * @return SimpleHtmlDomInterface[]|SimpleHtmlDomNodeInterface<SimpleHtmlDomInterface>
  */
 function find_contains(
-    \voku\helper\HtmlDomParser $dom,
+    \Voku\Helper\HtmlDomParser $dom,
     string $selector,
     string $keyword
 ) {
@@ -38,7 +38,7 @@ $html = '
 <ul><li class="lall">test321<br>foo</li><!----></ul>
 ';
 
-$document = new \voku\helper\HtmlDomParser($html);
+$document = new \Voku\Helper\HtmlDomParser($html);
 
 foreach (find_contains($document, '.lall', 'foo') as $child_dom) {
     echo $child_dom->html() . "\n";

--- a/example/example_modify_attribute.php
+++ b/example/example_modify_attribute.php
@@ -1,6 +1,6 @@
 <?php
 
-use voku\helper\HtmlDomParser;
+use Voku\Helper\HtmlDomParser;
 
 require_once '../vendor/autoload.php';
 

--- a/example/example_modify_contents.php
+++ b/example/example_modify_contents.php
@@ -1,6 +1,6 @@
 <?php
 
-use voku\helper\HtmlDomParser;
+use Voku\Helper\HtmlDomParser;
 
 require_once '../vendor/autoload.php';
 

--- a/example/example_modify_styles_with_svg.php
+++ b/example/example_modify_styles_with_svg.php
@@ -1,6 +1,6 @@
 <?php
 
-use voku\helper\HtmlDomParser;
+use Voku\Helper\HtmlDomParser;
 
 require_once '../vendor/autoload.php';
 

--- a/example/example_remove_comments.php
+++ b/example/example_remove_comments.php
@@ -6,7 +6,7 @@ require_once '../vendor/autoload.php';
 function html_no_comment(string $html): string
 {
     // create HTML DOM
-    $dom = \voku\helper\HtmlDomParser::str_get_html($html);
+    $dom = \Voku\Helper\HtmlDomParser::str_get_html($html);
 
     // remove all comment elements
     foreach ($dom->find('comment') as $e) {

--- a/example/example_remove_content.php
+++ b/example/example_remove_content.php
@@ -1,6 +1,6 @@
 <?php
 
-use voku\helper\HtmlDomParser;
+use Voku\Helper\HtmlDomParser;
 
 require_once '../vendor/autoload.php';
 

--- a/example/example_remove_content_from_table.php
+++ b/example/example_remove_content_from_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use voku\helper\HtmlDomParser;
+use Voku\Helper\HtmlDomParser;
 
 require_once '../vendor/autoload.php';
 

--- a/example/example_scraping_imdb.php
+++ b/example/example_scraping_imdb.php
@@ -8,7 +8,7 @@ function scraping_imdb($url)
     $return = [];
 
     // create HTML DOM
-    $dom = \voku\helper\HtmlDomParser::file_get_html($url);
+    $dom = \Voku\Helper\HtmlDomParser::file_get_html($url);
 
     // get title
     $return['Title'] = $dom->find('title', 0)->innertext;

--- a/example/example_scraping_lebensmittelwarnung.php
+++ b/example/example_scraping_lebensmittelwarnung.php
@@ -8,7 +8,7 @@ function scraping_lebensmittelwarnung($url)
     $return = [];
 
     // create HTML DOM
-    $dom = \voku\helper\HtmlDomParser::file_get_html($url);
+    $dom = \Voku\Helper\HtmlDomParser::file_get_html($url);
 
     foreach ($dom->findMulti('item') as $item) {
         $title = $item->getElementByTagName('title')->text();

--- a/src/voku/helper/AbstractDomParser.php
+++ b/src/voku/helper/AbstractDomParser.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 abstract class AbstractDomParser implements DomParserInterface
 {
@@ -57,7 +57,7 @@ abstract class AbstractDomParser implements DomParserInterface
     /**
      * @var callable|null
      *
-     * @phpstan-var null|callable(\voku\helper\XmlDomParser|\voku\helper\HtmlDomParser): void
+     * @phpstan-var null|callable(\Voku\Helper\XmlDomParser|\Voku\Helper\HtmlDomParser): void
      */
     protected static $callback;
 
@@ -152,7 +152,7 @@ abstract class AbstractDomParser implements DomParserInterface
     protected function decodeHtmlEntity(string $content, bool $multiDecodeNewHtmlEntity): string
     {
         if ($multiDecodeNewHtmlEntity) {
-            if (\class_exists('\voku\helper\UTF8')) {
+            if (\class_exists('\Voku\Helper\UTF8')) {
                 $content = UTF8::rawurldecode($content, true);
             } else {
                 do {
@@ -168,7 +168,7 @@ abstract class AbstractDomParser implements DomParserInterface
             }
         } else {
             /** @noinspection NestedPositiveIfStatementsInspection */
-            if (\class_exists('\voku\helper\UTF8')) {
+            if (\class_exists('\Voku\Helper\UTF8')) {
                 $content = UTF8::rawurldecode($content, false);
             } else {
                 $content = \rawurldecode(
@@ -332,7 +332,7 @@ abstract class AbstractDomParser implements DomParserInterface
     /**
      * @param callable $functionName
      *
-     * @phpstan-param callable(\voku\helper\XmlDomParser|\voku\helper\HtmlDomParser): void $functionName
+     * @phpstan-param callable(\Voku\Helper\XmlDomParser|\Voku\Helper\HtmlDomParser): void $functionName
      *
      * @return void
      */

--- a/src/voku/helper/AbstractSimpleHtmlDom.php
+++ b/src/voku/helper/AbstractSimpleHtmlDom.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 abstract class AbstractSimpleHtmlDom
 {

--- a/src/voku/helper/AbstractSimpleHtmlDomNode.php
+++ b/src/voku/helper/AbstractSimpleHtmlDomNode.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * {@inheritdoc}

--- a/src/voku/helper/AbstractSimpleXmlDom.php
+++ b/src/voku/helper/AbstractSimpleXmlDom.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 abstract class AbstractSimpleXmlDom
 {

--- a/src/voku/helper/AbstractSimpleXmlDomNode.php
+++ b/src/voku/helper/AbstractSimpleXmlDomNode.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * {@inheritdoc}

--- a/src/voku/helper/DomParserInterface.php
+++ b/src/voku/helper/DomParserInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace voku\helper;
+namespace HVoku\elper;
 
 interface DomParserInterface
 {

--- a/src/voku/helper/HtmlDomHelper.php
+++ b/src/voku/helper/HtmlDomHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 final class HtmlDomHelper
 {
@@ -23,8 +23,8 @@ final class HtmlDomHelper
             return $html;
         }
 
-        $dom = \voku\helper\HtmlDomParser::str_get_html($html);
-        $domNew = \voku\helper\HtmlDomParser::str_get_html('<textarea ' . $optionStr . '></textarea>');
+        $dom = \Voku\Helper\HtmlDomParser::str_get_html($html);
+        $domNew = \Voku\Helper\HtmlDomParser::str_get_html('<textarea ' . $optionStr . '></textarea>');
 
         $domElement = $dom->findOneOrFalse($htmlCssSelector);
         if ($domElement === false) {

--- a/src/voku/helper/HtmlDomParser.php
+++ b/src/voku/helper/HtmlDomParser.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * @property-read string $outerText
@@ -36,14 +36,14 @@ class HtmlDomParser extends AbstractDomParser
     /**
      * @var callable|null
      *
-     * @phpstan-var null|callable(string $cssSelectorString, string $xPathString, \DOMXPath, \voku\helper\HtmlDomParser): string
+     * @phpstan-var null|callable(string $cssSelectorString, string $xPathString, \DOMXPath, \Voku\Helper\HtmlDomParser): string
      */
     private $callbackXPathBeforeQuery;
 
     /**
      * @var callable|null
      *
-     * @phpstan-var null|callable(string $htmlString, \voku\helper\HtmlDomParser): string
+     * @phpstan-var null|callable(string $htmlString, \Voku\Helper\HtmlDomParser): string
      */
     private $callbackBeforeCreateDom;
 
@@ -896,8 +896,8 @@ class HtmlDomParser extends AbstractDomParser
         }
 
         try {
-            if (\class_exists('\voku\helper\UTF8')) {
-                $html = \voku\helper\UTF8::file_get_contents($filePath);
+            if (\class_exists('\Voku\Helper\UTF8')) {
+                $html = \Voku\Helper\UTF8::file_get_contents($filePath);
             } else {
                 $html = \file_get_contents($filePath);
             }
@@ -1201,7 +1201,7 @@ class HtmlDomParser extends AbstractDomParser
     /**
      * @param callable $callbackXPathBeforeQuery
      *
-     * @phpstan-param callable(string $cssSelectorString, string $xPathString,\DOMXPath,\voku\helper\HtmlDomParser): string $callbackXPathBeforeQuery
+     * @phpstan-param callable(string $cssSelectorString, string $xPathString,\DOMXPath,\Voku\Velper\HtmlDomParser): string $callbackXPathBeforeQuery
      *
      * @return $this
      */
@@ -1215,7 +1215,7 @@ class HtmlDomParser extends AbstractDomParser
     /**
      * @param callable $callbackBeforeCreateDom
      *
-     * @phpstan-param callable(string $htmlString, \voku\helper\HtmlDomParser): string $callbackBeforeCreateDom
+     * @phpstan-param callable(string $htmlString, \Voku\Helper\HtmlDomParser): string $callbackBeforeCreateDom
      *
      * @return $this
      */

--- a/src/voku/helper/SelectorConverter.php
+++ b/src/voku/helper/SelectorConverter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 use Symfony\Component\CssSelector\CssSelectorConverter;
 

--- a/src/voku/helper/SimpleHtmlAttributes.php
+++ b/src/voku/helper/SimpleHtmlAttributes.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * {@inheritdoc}

--- a/src/voku/helper/SimpleHtmlAttributesInterface.php
+++ b/src/voku/helper/SimpleHtmlAttributesInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * Represents a set of space-separated attributes of an element attribute.

--- a/src/voku/helper/SimpleHtmlDom.php
+++ b/src/voku/helper/SimpleHtmlDom.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * @noinspection PhpHierarchyChecksInspection

--- a/src/voku/helper/SimpleHtmlDomBlank.php
+++ b/src/voku/helper/SimpleHtmlDomBlank.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * @noinspection PhpHierarchyChecksInspection

--- a/src/voku/helper/SimpleHtmlDomInterface.php
+++ b/src/voku/helper/SimpleHtmlDomInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * @property string      $outertext

--- a/src/voku/helper/SimpleHtmlDomNode.php
+++ b/src/voku/helper/SimpleHtmlDomNode.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * {@inheritdoc}

--- a/src/voku/helper/SimpleHtmlDomNodeBlank.php
+++ b/src/voku/helper/SimpleHtmlDomNodeBlank.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * {@inheritdoc}

--- a/src/voku/helper/SimpleHtmlDomNodeInterface.php
+++ b/src/voku/helper/SimpleHtmlDomNodeInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * @property-read int      $length

--- a/src/voku/helper/SimpleXmlDom.php
+++ b/src/voku/helper/SimpleXmlDom.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * @noinspection PhpHierarchyChecksInspection

--- a/src/voku/helper/SimpleXmlDomBlank.php
+++ b/src/voku/helper/SimpleXmlDomBlank.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * @noinspection PhpHierarchyChecksInspection

--- a/src/voku/helper/SimpleXmlDomInterface.php
+++ b/src/voku/helper/SimpleXmlDomInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * @property string      $outertext

--- a/src/voku/helper/SimpleXmlDomNode.php
+++ b/src/voku/helper/SimpleXmlDomNode.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * {@inheritdoc}

--- a/src/voku/helper/SimpleXmlDomNodeBlank.php
+++ b/src/voku/helper/SimpleXmlDomNodeBlank.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * {@inheritdoc}

--- a/src/voku/helper/SimpleXmlDomNodeInterface.php
+++ b/src/voku/helper/SimpleXmlDomNodeInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * @property-read int      $length

--- a/src/voku/helper/XmlDomParser.php
+++ b/src/voku/helper/XmlDomParser.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * @property-read string $plaintext
@@ -18,14 +18,14 @@ class XmlDomParser extends AbstractDomParser
     /**
      * @var callable|null
      *
-     * @phpstan-var null|callable(string $cssSelectorString, string $xPathString, \DOMXPath, \voku\helper\XmlDomParser): string
+     * @phpstan-var null|callable(string $cssSelectorString, string $xPathString, \DOMXPath, \Voku\Helper\XmlDomParser): string
      */
     private $callbackXPathBeforeQuery;
 
     /**
      * @var callable|null
      *
-     * @phpstan-var null|callable(string $xmlString, \voku\helper\XmlDomParser): string
+     * @phpstan-var null|callable(string $xmlString, \Voku\Helper\XmlDomParser): string
      */
     private $callbackBeforeCreateDom;
 
@@ -534,8 +534,8 @@ class XmlDomParser extends AbstractDomParser
         }
 
         try {
-            if (\class_exists('\voku\helper\UTF8')) {
-                $html = \voku\helper\UTF8::file_get_contents($filePath);
+            if (\class_exists('\Voku\Helper\UTF8')) {
+                $html = \Voku\Helper\UTF8::file_get_contents($filePath);
             } else {
                 $html = \file_get_contents($filePath);
             }
@@ -613,8 +613,8 @@ class XmlDomParser extends AbstractDomParser
         }
 
         try {
-            if (\class_exists('\voku\helper\UTF8')) {
-                $xml = \voku\helper\UTF8::file_get_contents($filePath);
+            if (\class_exists('\Voku\Helper\UTF8')) {
+                $xml = \Voku\Helper\UTF8::file_get_contents($filePath);
             } else {
                 $xml = \file_get_contents($filePath);
             }
@@ -695,7 +695,7 @@ class XmlDomParser extends AbstractDomParser
     /**
      * @param callable $callbackXPathBeforeQuery
      *
-     * @phpstan-param callable(string $cssSelectorString, string $xPathString, \DOMXPath, \voku\helper\XmlDomParser): string $callbackXPathBeforeQuery
+     * @phpstan-param callable(string $cssSelectorString, string $xPathString, \DOMXPath, \Voku\Helper\XmlDomParser): string $callbackXPathBeforeQuery
      *
      * @return $this
      */
@@ -709,7 +709,7 @@ class XmlDomParser extends AbstractDomParser
     /**
      * @param callable $callbackBeforeCreateDom
      *
-     * @phpstan-param callable(string $xmlString, \voku\helper\XmlDomParser): string $callbackBeforeCreateDom
+     * @phpstan-param callable(string $xmlString, \Voku\Helper\XmlDomParser): string $callbackBeforeCreateDom
      *
      * @return $this
      */

--- a/tests/AuxiliarFunctionsTest.php
+++ b/tests/AuxiliarFunctionsTest.php
@@ -2,7 +2,7 @@
 
 
 use PHPUnit\Framework\TestCase;
-use voku\helper\HtmlDomParser;
+use Voku\Helper\HtmlDomParser;
 
 final class AuxiliarFunctionsTest extends TestCase
 {

--- a/tests/CommentTest.php
+++ b/tests/CommentTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
-use voku\helper\HtmlDomParser;
+use Voku\Helper\HtmlDomParser;
 
 /**
  * Checks if the parser properly handles comments

--- a/tests/DomManipulationTest.php
+++ b/tests/DomManipulationTest.php
@@ -2,7 +2,7 @@
 
 use PHPUnit\Framework\TestCase;
 
-use voku\helper\HtmlDomParser;
+use Voku\Helper\HtmlDomParser;
 
 /**
  * Tests the DOM manipulation ability of the parser

--- a/tests/HTML5DOMDocumentTest.php
+++ b/tests/HTML5DOMDocumentTest.php
@@ -7,7 +7,7 @@
  * Free to use under the MIT license.
  */
 
-use voku\helper\HtmlDomParser;
+use Voku\Helper\HtmlDomParser;
 
 /**
  * @runTestsInSeparateProcesses

--- a/tests/HtmlDomParserTest.php
+++ b/tests/HtmlDomParserTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use voku\helper\HtmlDomParser;
-use voku\helper\SimpleHtmlDom;
-use voku\helper\SimpleHtmlDomInterface;
-use voku\helper\SimpleHtmlDomNode;
-use voku\helper\SimpleHtmlDomNodeInterface;
+use Voku\Helper\HtmlDomParser;
+use Voku\Helper\SimpleHtmlDom;
+use Voku\Helper\SimpleHtmlDomInterface;
+use Voku\Helper\SimpleHtmlDomNode;
+use Voku\Helper\SimpleHtmlDomNodeInterface;
 
 /**
  * @internal
@@ -133,7 +133,7 @@ final class HtmlDomParserTest extends \PHPUnit\Framework\TestCase
     public function testHrefReplacing()
     {
         $origUrl = 'https://test.com?param1=1&param2=2';
-        $document = \voku\helper\HtmlDomParser::str_get_html("<a href='" . $origUrl . "'></a>");
+        $document = \Voku\Helper\HtmlDomParser::str_get_html("<a href='" . $origUrl . "'></a>");
         $link = $document->findOne('a');
         $link->setAttribute('href', 'https://redirect.com?rdr=' . \urlencode($link->getAttribute('href')));
 
@@ -172,7 +172,7 @@ final class HtmlDomParserTest extends \PHPUnit\Framework\TestCase
         // ---
 
         // this only works with "UTF8"-helpers
-        if (\class_exists('\voku\helper\UTF8')) {
+        if (\class_exists('\Voku\Helper\UTF8')) {
             static::assertSame(['ÅÄÖ', 'åäö'], $document->find('li')->text());
         }
     }
@@ -225,16 +225,16 @@ final class HtmlDomParserTest extends \PHPUnit\Framework\TestCase
         $document = new HtmlDomParser($html);
         $elements = $document->find($selector);
 
-        static::assertInstanceOf(voku\helper\SimpleHtmlDomNodeInterface::class, $elements);
+        static::assertInstanceOf(Voku\Helper\SimpleHtmlDomNodeInterface::class, $elements);
         static::assertCount($count, $elements);
 
         foreach ($elements as $element) {
-            static::assertInstanceOf(voku\helper\SimpleHtmlDomInterface::class, $element);
+            static::assertInstanceOf(Voku\Helper\SimpleHtmlDomInterface::class, $element);
         }
 
         if ($count !== 0) {
             $element = $document->find($selector, -1);
-            static::assertInstanceOf(voku\helper\SimpleHtmlDomInterface::class, $element);
+            static::assertInstanceOf(Voku\Helper\SimpleHtmlDomInterface::class, $element);
         }
     }
 
@@ -685,7 +685,7 @@ test3Html.html                      <foo id="foo">bar</foo>
 HTML;
 
         $htmlTmp = HtmlDomParser::str_get_html($str);
-        static::assertInstanceOf(voku\helper\HtmlDomParser::class, $htmlTmp);
+        static::assertInstanceOf(Voku\Helper\HtmlDomParser::class, $htmlTmp);
 
         // replace all images with "foobar"
         $tmpArray = [];
@@ -849,8 +849,8 @@ HTML;
             return $html;
         }
 
-        $dom = \voku\helper\HtmlDomParser::str_get_html($html);
-        $domNew = \voku\helper\HtmlDomParser::str_get_html('<textarea ' . $optionStr . '></textarea>');
+        $dom = \Voku\Helper\HtmlDomParser::str_get_html($html);
+        $domNew = \Voku\Helper\HtmlDomParser::str_get_html('<textarea ' . $optionStr . '></textarea>');
 
         $domElement = $dom->findOneOrFalse($htmlCssSelector);
         if ($domElement === false) {
@@ -915,12 +915,12 @@ HTML;
 
         $html = new HtmlDomParser();
         $html->setCallbackBeforeCreateDom(
-            static function (string $str, \voku\helper\HtmlDomParser $htmlParser) {
+            static function (string $str, \Voku\Helper\HtmlDomParser $htmlParser) {
                 return \str_replace('ノ', '?', $str);
             }
         );
         $html->setCallbackXPathBeforeQuery(
-            static function (string $cssSelectorString, string $xPathString, \DOMXPath $xPath, \voku\helper\HtmlDomParser $htmlParser) {
+            static function (string $cssSelectorString, string $xPathString, \DOMXPath $xPath, \Voku\Helper\HtmlDomParser $htmlParser) {
                 return $cssSelectorString === 'xxx' ? '//p' : $xPathString;
             }
         );
@@ -2200,7 +2200,7 @@ ___;
 
         // ---
 
-        $d = new voku\helper\HtmlDomParser();
+        $d = new Voku\Helper\HtmlDomParser();
         $d->overwriteTemplateLogicSyntaxInSpecialScriptTags(['{#']);
         $d->loadHtml($html);
 
@@ -2231,7 +2231,7 @@ ___;
 
         // ---
 
-        $d = new voku\helper\HtmlDomParser();
+        $d = new Voku\Helper\HtmlDomParser();
         $d->overwriteTemplateLogicSyntaxInSpecialScriptTags(['{%']);
         $d->loadHtml($html);
 
@@ -2265,7 +2265,7 @@ ___;
     {
         static::expectException(InvalidArgumentException::class);
 
-        $d = new voku\helper\HtmlDomParser();
+        $d = new Voku\Helper\HtmlDomParser();
         $d->overwriteTemplateLogicSyntaxInSpecialScriptTags([['{{']]);
     }
 
@@ -2284,7 +2284,7 @@ ___;
 
     public function testIssue42()
     {
-        $d = new voku\helper\HtmlDomParser();
+        $d = new Voku\Helper\HtmlDomParser();
 
         $d->loadHtml('<p>p1</p><p>p2</p>');
         static::assertSame('<p>p1</p><p>p2</p>', (string) $d);
@@ -2295,7 +2295,7 @@ ___;
 
     public function testIssue53()
     {
-        $d = new voku\helper\HtmlDomParser();
+        $d = new Voku\Helper\HtmlDomParser();
 
         $html = '
         <blockquote class="bg-gray primary">
@@ -2365,7 +2365,7 @@ ___;
         </div>
         </html>';
 
-        $domTree = \voku\helper\HtmlDomParser::str_get_html($html);
+        $domTree = \Voku\Helper\HtmlDomParser::str_get_html($html);
 
         static::assertSame($expected, $domTree->html());
 
@@ -2418,7 +2418,7 @@ ___;
         </div>
         </html>';
 
-        $domTree = \voku\helper\HtmlDomParser::str_get_html($html);
+        $domTree = \Voku\Helper\HtmlDomParser::str_get_html($html);
 
         static::assertSame($expected, $domTree->html());
 
@@ -2545,7 +2545,7 @@ ___;
         <div class='services active'></div>
         ";
 
-        $d = new voku\helper\HtmlDomParser();
+        $d = new Voku\Helper\HtmlDomParser();
         $d->load($html);
 
         $htmlResult = '';
@@ -2560,7 +2560,7 @@ ___;
 
         // ---
 
-        $d = new voku\helper\HtmlDomParser();
+        $d = new Voku\Helper\HtmlDomParser();
         $d->load($html);
 
         $htmlResult = '';

--- a/tests/SimpleHtmlDomMemoryTest.php
+++ b/tests/SimpleHtmlDomMemoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use voku\helper\HtmlDomParser;
+use Voku\Helper\HtmlDomParser;
 
 /**
  * @internal

--- a/tests/SimpleHtmlDomNodeTest.php
+++ b/tests/SimpleHtmlDomNodeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use voku\helper\HtmlDomParser;
+use Voku\Helper\HtmlDomParser;
 
 /**
  * @internal
@@ -36,11 +36,11 @@ final class SimpleHtmlDomNodeTest extends \PHPUnit\Framework\TestCase
 
         $elements = $nodeList->find($selector);
 
-        static::assertInstanceOf(voku\helper\SimpleHtmlDomNodeInterface::class, $elements);
+        static::assertInstanceOf(Voku\Helper\SimpleHtmlDomNodeInterface::class, $elements);
         static::assertCount($count, $elements);
 
         foreach ($elements as $node) {
-            static::assertInstanceOf(voku\helper\SimpleHtmlDom::class, $node);
+            static::assertInstanceOf(Voku\Helper\SimpleHtmlDom::class, $node);
         }
     }
 
@@ -93,8 +93,8 @@ final class SimpleHtmlDomNodeTest extends \PHPUnit\Framework\TestCase
         $document = new HtmlDomParser($html);
         $element = $document->find('span');
 
-        static::assertInstanceOf(\voku\helper\SimpleHtmlDomNodeInterface::class, $element);
-        static::assertInstanceOf(\voku\helper\SimpleHtmlDomNodeBlank::class, $element);
+        static::assertInstanceOf(\Voku\Helper\SimpleHtmlDomNodeInterface::class, $element);
+        static::assertInstanceOf(\Voku\Helper\SimpleHtmlDomNodeBlank::class, $element);
         static::assertSame([], $element->text());
         static::assertSame([], $element->plaintext);
     }
@@ -105,8 +105,8 @@ final class SimpleHtmlDomNodeTest extends \PHPUnit\Framework\TestCase
         $document = new HtmlDomParser($html);
         $element = $document->find('span', 0);
 
-        static::assertInstanceOf(\voku\helper\SimpleHtmlDomInterface::class, $element);
-        static::assertInstanceOf(\voku\helper\SimpleHtmlDomBlank::class, $element);
+        static::assertInstanceOf(\Voku\Helper\SimpleHtmlDomInterface::class, $element);
+        static::assertInstanceOf(\Voku\Helper\SimpleHtmlDomBlank::class, $element);
         static::assertSame('', $element->class);
         static::assertSame('', $element->text());
         static::assertSame('', $element->plaintext);
@@ -119,8 +119,8 @@ final class SimpleHtmlDomNodeTest extends \PHPUnit\Framework\TestCase
         $elements = $document->find('span', 1);
 
         static::assertCount(0, $elements);
-        static::assertInstanceOf(\voku\helper\SimpleHtmlDomInterface::class, $elements);
-        static::assertInstanceOf(\voku\helper\SimpleHtmlDomBlank::class, $elements);
+        static::assertInstanceOf(\Voku\Helper\SimpleHtmlDomInterface::class, $elements);
+        static::assertInstanceOf(\Voku\Helper\SimpleHtmlDomBlank::class, $elements);
         static::assertSame('', $elements->class);
         static::assertSame('', $elements->text());
         static::assertSame('', $elements->plaintext);

--- a/tests/SimpleHtmlDomTest.php
+++ b/tests/SimpleHtmlDomTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use voku\helper\HtmlDomParser;
-use voku\helper\SimpleHtmlDom;
+use Voku\Helper\HtmlDomParser;
+use Voku\Helper\SimpleHtmlDom;
 
 /**
  * @internal
@@ -126,12 +126,12 @@ final class SimpleHtmlDomTest extends \PHPUnit\Framework\TestCase
 
     public function testIssue63()
     {
-        $dom = (new voku\helper\HtmlDomParser())->loadHtml('<div> foo bar </div>');
+        $dom = (new Voku\Helper\HtmlDomParser())->loadHtml('<div> foo bar </div>');
         static::assertSame('foo bar', $dom->findOne('div')->innerHtml());
-        static::assertInstanceOf(\voku\helper\SimpleHtmlDomBlank::class, $dom->findOne('span'));
-        static::assertInstanceOf(\voku\helper\SimpleHtmlDomBlank::class, $dom->findOne('span')->findOne('span'));
-        static::assertInstanceOf(\voku\helper\SimpleHtmlDomBlank::class, $dom->findOne('span')->findOne('span')->findOne('span'));
-        static::assertInstanceOf(\voku\helper\SimpleHtmlDomBlank::class, $dom->findOne('span')->findOne('span')->findOne('span')->findOne('span'));
+        static::assertInstanceOf(\Voku\Helper\SimpleHtmlDomBlank::class, $dom->findOne('span'));
+        static::assertInstanceOf(\Voku\Helper\SimpleHtmlDomBlank::class, $dom->findOne('span')->findOne('span'));
+        static::assertInstanceOf(\Voku\Helper\SimpleHtmlDomBlank::class, $dom->findOne('span')->findOne('span')->findOne('span'));
+        static::assertInstanceOf(\Voku\Helper\SimpleHtmlDomBlank::class, $dom->findOne('span')->findOne('span')->findOne('span')->findOne('span'));
     }
 
     public function testCommentWp()
@@ -142,7 +142,7 @@ final class SimpleHtmlDomTest extends \PHPUnit\Framework\TestCase
         <!-- /wp:heading -->
         ';
 
-        $d = new voku\helper\HtmlDomParser();
+        $d = new Voku\Helper\HtmlDomParser();
         $d->loadHtml($html);
 
         static::assertSame($html, $d->html());
@@ -150,7 +150,7 @@ final class SimpleHtmlDomTest extends \PHPUnit\Framework\TestCase
 
     public function testAppendPrependIssue()
     {
-        $d = new voku\helper\HtmlDomParser();
+        $d = new Voku\Helper\HtmlDomParser();
         $d->loadHtml('<p>p1</p><p>p2</p>');
         $p = $d->find('p', 0);
         $p->outerhtml .= '<div>outer</div>';
@@ -173,7 +173,7 @@ final class SimpleHtmlDomTest extends \PHPUnit\Framework\TestCase
 </p>
 ';
 
-        $d = new voku\helper\HtmlDomParser();
+        $d = new Voku\Helper\HtmlDomParser();
         $d->loadHtml($html);
 
         static::assertSame($html, $d->html());
@@ -257,7 +257,7 @@ final class SimpleHtmlDomTest extends \PHPUnit\Framework\TestCase
         $node = $document->getDocument()->documentElement;
         $element = new SimpleHtmlDom($node);
 
-        static::assertInstanceOf(voku\helper\HtmlDomParser::class, $element->getHtmlDomParser());
+        static::assertInstanceOf(Voku\Helper\HtmlDomParser::class, $element->getHtmlDomParser());
     }
 
     /**
@@ -274,16 +274,16 @@ final class SimpleHtmlDomTest extends \PHPUnit\Framework\TestCase
 
         $elements = $element->find($selector);
 
-        static::assertInstanceOf(voku\helper\SimpleHtmlDomNodeInterface::class, $elements);
+        static::assertInstanceOf(Voku\Helper\SimpleHtmlDomNodeInterface::class, $elements);
         static::assertCount($count, $elements);
 
         foreach ($elements as $node) {
-            static::assertInstanceOf(voku\helper\SimpleHtmlDomInterface::class, $node);
+            static::assertInstanceOf(Voku\Helper\SimpleHtmlDomInterface::class, $node);
         }
 
         $elements = $element($selector);
 
-        static::assertInstanceOf(voku\helper\SimpleHtmlDomNodeInterface::class, $elements);
+        static::assertInstanceOf(Voku\Helper\SimpleHtmlDomNodeInterface::class, $elements);
     }
 
     /**
@@ -318,7 +318,7 @@ final class SimpleHtmlDomTest extends \PHPUnit\Framework\TestCase
 
         $node = $element->getElementById('in');
 
-        static::assertInstanceOf(voku\helper\SimpleHtmlDom::class, $node);
+        static::assertInstanceOf(Voku\Helper\SimpleHtmlDom::class, $node);
         static::assertSame('input', $node->tag);
         static::assertSame('input', $node->nodeName);
         static::assertSame('number', $node->type);
@@ -334,7 +334,7 @@ final class SimpleHtmlDomTest extends \PHPUnit\Framework\TestCase
 
         $node = $element->getElementByTagName('div');
 
-        static::assertInstanceOf(voku\helper\SimpleHtmlDom::class, $node);
+        static::assertInstanceOf(Voku\Helper\SimpleHtmlDom::class, $node);
         static::assertSame('div', $node->tag);
         static::assertSame('top', $node->id);
         static::assertSame('page', $node->class);
@@ -349,11 +349,11 @@ final class SimpleHtmlDomTest extends \PHPUnit\Framework\TestCase
 
         $elements = $element->getElementsByTagName('div');
 
-        static::assertInstanceOf(\voku\helper\SimpleHtmlDomNode::class, $elements);
+        static::assertInstanceOf(\Voku\Helper\SimpleHtmlDomNode::class, $elements);
         static::assertCount(16, $elements);
 
         foreach ($elements as $node) {
-            static::assertInstanceOf(voku\helper\SimpleHtmlDom::class, $node);
+            static::assertInstanceOf(Voku\Helper\SimpleHtmlDom::class, $node);
         }
     }
 
@@ -366,16 +366,16 @@ final class SimpleHtmlDomTest extends \PHPUnit\Framework\TestCase
 
         $nodes = $element->childNodes();
 
-        static::assertInstanceOf(voku\helper\SimpleHtmlDomNode::class, $nodes);
+        static::assertInstanceOf(Voku\Helper\SimpleHtmlDomNode::class, $nodes);
         static::assertCount(2, $nodes);
 
         foreach ($nodes as $node) {
-            static::assertInstanceOf(voku\helper\SimpleHtmlDom::class, $node);
+            static::assertInstanceOf(Voku\Helper\SimpleHtmlDom::class, $node);
         }
 
         $node = $element->childNodes(1);
 
-        static::assertInstanceOf(voku\helper\SimpleHtmlDom::class, $node);
+        static::assertInstanceOf(Voku\Helper\SimpleHtmlDom::class, $node);
 
         static::assertSame('<p>bar</p>', $node->outertext);
         static::assertSame('bar', $node->plaintext);
@@ -393,16 +393,16 @@ final class SimpleHtmlDomTest extends \PHPUnit\Framework\TestCase
 
         $nodes = $element->children();
 
-        static::assertInstanceOf(voku\helper\SimpleHtmlDomNode::class, $nodes);
+        static::assertInstanceOf(Voku\Helper\SimpleHtmlDomNode::class, $nodes);
         static::assertCount(2, $nodes);
 
         foreach ($nodes as $node) {
-            static::assertInstanceOf(voku\helper\SimpleHtmlDom::class, $node);
+            static::assertInstanceOf(Voku\Helper\SimpleHtmlDom::class, $node);
         }
 
         $node = $element->children(1);
 
-        static::assertInstanceOf(voku\helper\SimpleHtmlDom::class, $node);
+        static::assertInstanceOf(Voku\Helper\SimpleHtmlDom::class, $node);
 
         static::assertSame('<p>bar</p>', $node->outertext);
         static::assertSame('bar', $node->plaintext);
@@ -417,13 +417,13 @@ final class SimpleHtmlDomTest extends \PHPUnit\Framework\TestCase
 
         $node = $element->firstChild();
 
-        static::assertInstanceOf(voku\helper\SimpleHtmlDom::class, $node);
+        static::assertInstanceOf(Voku\Helper\SimpleHtmlDom::class, $node);
         static::assertSame('<p>foo</p>', $node->outertext);
         static::assertSame('foo', $node->plaintext);
 
         $node = $element->lastChild();
 
-        static::assertInstanceOf(voku\helper\SimpleHtmlDom::class, $node);
+        static::assertInstanceOf(Voku\Helper\SimpleHtmlDom::class, $node);
         static::assertSame('<p></p>', $node->outertext);
         static::assertSame('', $node->plaintext);
 
@@ -440,13 +440,13 @@ final class SimpleHtmlDomTest extends \PHPUnit\Framework\TestCase
 
         $node = $element->lastChild();
 
-        static::assertInstanceOf(voku\helper\SimpleHtmlDom::class, $node);
+        static::assertInstanceOf(Voku\Helper\SimpleHtmlDom::class, $node);
         static::assertSame('<p>bar</p>', $node->outertext);
         static::assertSame('bar', $node->plaintext);
 
         $node = $element->firstChild();
 
-        static::assertInstanceOf(voku\helper\SimpleHtmlDom::class, $node);
+        static::assertInstanceOf(Voku\Helper\SimpleHtmlDom::class, $node);
         static::assertSame('<p></p>', $node->outertext);
         static::assertSame('', $node->plaintext);
 
@@ -474,7 +474,7 @@ final class SimpleHtmlDomTest extends \PHPUnit\Framework\TestCase
         $node = $element->firstChild();
         $sibling = $node->nextSibling();
 
-        static::assertInstanceOf(voku\helper\SimpleHtmlDom::class, $sibling);
+        static::assertInstanceOf(Voku\Helper\SimpleHtmlDom::class, $sibling);
         static::assertSame('<p>bar</p>', $sibling->outertext);
         static::assertSame('bar', $sibling->plaintext);
 
@@ -494,7 +494,7 @@ final class SimpleHtmlDomTest extends \PHPUnit\Framework\TestCase
         $node = $element->lastChild();
         $sibling = $node->previousSibling();
 
-        static::assertInstanceOf(voku\helper\SimpleHtmlDom::class, $sibling);
+        static::assertInstanceOf(Voku\Helper\SimpleHtmlDom::class, $sibling);
         static::assertSame('<p>foo</p>', $sibling->outertext);
         static::assertSame('foo', $sibling->plaintext);
 
@@ -513,7 +513,7 @@ final class SimpleHtmlDomTest extends \PHPUnit\Framework\TestCase
 
         $node = $element->parentNode();
 
-        static::assertInstanceOf(voku\helper\SimpleHtmlDom::class, $node);
+        static::assertInstanceOf(Voku\Helper\SimpleHtmlDom::class, $node);
         static::assertSame('div', $node->tag);
         /** @noinspection PhpUndefinedFieldInspection */
         static::assertSame('div', $element->parent()->tag);

--- a/tests/SimpleHtmlHelperTest.php
+++ b/tests/SimpleHtmlHelperTest.php
@@ -2,7 +2,7 @@
 
 use PHPUnit\Framework\TestCase;
 
-use voku\helper\HtmlDomHelper;
+use Voku\Helper\HtmlDomHelper;
 
 /**
  * @internal

--- a/tests/TwigTest.php
+++ b/tests/TwigTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use voku\helper\HtmlDomParser;
+use Voku\Helper\HtmlDomParser;
 
 /**
  * @internal

--- a/tests/XmlDomParserTest.php
+++ b/tests/XmlDomParserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use voku\helper\XmlDomParser;
+use Voku\Helper\XmlDomParser;
 
 /**
  * @internal
@@ -25,7 +25,7 @@ final class XmlDomParserTest extends \PHPUnit\Framework\TestCase
     public function testXMLWithoutLoadingDtd() {
         $cxmlData = '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE cXML SYSTEM "http://xml.cXML.org/schemas/cXML/1.2.024/cXML.dtd"><cXML payloadID="dsfsfsdds" timestamp="2022-12-21T15:35:02+01:00" xml:lang="en-US"><Header><From><Credential domain="NetworkId"><Identity>sdfdfsdf-123</Identity></Credential></From><To><Credential domain="NetworkId"><Identity>fsdfdsfdsfds-321</Identity></Credential></To><Sender><Credential domain="NetworkId"><Identity>fsdfdsfds-1234</Identity></Credential><UserAgent>vdmg: Moelleken, Lars (VDMG-Connect)</UserAgent></Sender></Header><Message><PunchOutOrderMessage><BuyerCookie/><PunchOutOrderMessageHeader operationAllowed="edit"><Total><Money currency="EUR">2.13</Money></Total></PunchOutOrderMessageHeader><ItemIn quantity="1"><ItemID><SupplierPartID>43423342</SupplierPartID></ItemID><ItemDetail><UnitPrice><Money currency="EUR">2.13</Money></UnitPrice><Description xml:lang="de">Stahlblech 10 mm 1200</Description><Classification domain="UNSPSC"/></ItemDetail></ItemIn></PunchOutOrderMessage></Message></cXML>';
 
-        $xmlParser = new \voku\helper\XmlDomParser();
+        $xmlParser = new \Voku\Helper\XmlDomParser();
         $xmlParsed = $xmlParser->loadXml($cxmlData, LIBXML_NONET, false);
 
         $items = $xmlParsed->findMultiOrFalse('//ItemIn');
@@ -38,7 +38,7 @@ final class XmlDomParserTest extends \PHPUnit\Framework\TestCase
 
         $content = '<xml>broken xml<foo</xml>';
 
-        $xmlParser = new \voku\helper\XmlDomParser();
+        $xmlParser = new \Voku\Helper\XmlDomParser();
         $xmlParser->reportXmlErrorsAsException();
         $xmlParser->loadXml($content);
     }
@@ -47,7 +47,7 @@ final class XmlDomParserTest extends \PHPUnit\Framework\TestCase
     {
         $content = '<xml>broken xml<foo</xml>';
 
-        $xmlParser = new \voku\helper\XmlDomParser();
+        $xmlParser = new \Voku\Helper\XmlDomParser();
         $xmlParser->reportXmlErrorsAsException(false);
         /** @noinspection PhpUsageOfSilenceOperatorInspection */
         @$xmlParser->loadXml($content);
@@ -143,7 +143,7 @@ final class XmlDomParserTest extends \PHPUnit\Framework\TestCase
   </Message>
 </cXML>';
 
-        $xmlParser = new \voku\helper\XmlDomParser();
+        $xmlParser = new \Voku\Helper\XmlDomParser();
 
         // "Attempt to load network entity"
         $xml = \preg_replace('#cXML SYSTEM "http://xml.cxml.org/schemas/cXML/[\d.]*/cXML.dtd"#', 'cXML', $xml);
@@ -162,15 +162,15 @@ final class XmlDomParserTest extends \PHPUnit\Framework\TestCase
 
     public function testXmlFind()
     {
-        $xmlParser = new \voku\helper\XmlDomParser();
+        $xmlParser = new \Voku\Helper\XmlDomParser();
         $xmlParser->autoRemoveXPathNamespaces();
         $xmlParser->setCallbackBeforeCreateDom(
-            static function (string $str, \voku\helper\XmlDomParser $xmlParser) {
+            static function (string $str, \Voku\Helper\XmlDomParser $xmlParser) {
                 return \str_replace('array', 'arrayy', $str);
             }
         );
         $xmlParser->setCallbackXPathBeforeQuery(
-            static function (string $cssSelectorString, string $xPathString, \DOMXPath $xPath, \voku\helper\XmlDomParser $xmlParser) {
+            static function (string $cssSelectorString, string $xPathString, \DOMXPath $xPath, \Voku\Helper\XmlDomParser $xmlParser) {
                 return $cssSelectorString === 'methodsynopsis' ? '//methodsynopsis' : $xPathString;
             }
         );
@@ -188,7 +188,7 @@ final class XmlDomParserTest extends \PHPUnit\Framework\TestCase
 
     public function testXmlFindV2()
     {
-        $xmlParser = new \voku\helper\XmlDomParser();
+        $xmlParser = new \Voku\Helper\XmlDomParser();
         $xmlParser->autoRemoveXPathNamespaces();
 
         $filename = __DIR__ . '/fixtures/test_xml_complex_v2.xml';
@@ -209,7 +209,7 @@ final class XmlDomParserTest extends \PHPUnit\Framework\TestCase
 
     public function testXmlFindV21()
     {
-        $xmlParser = new \voku\helper\XmlDomParser();
+        $xmlParser = new \Voku\Helper\XmlDomParser();
 
         $filename = __DIR__ . '/fixtures/test_xml_complex_v2.xml';
         $content = \file_get_contents($filename);
@@ -221,7 +221,7 @@ final class XmlDomParserTest extends \PHPUnit\Framework\TestCase
 
     public function testXmlFindV3()
     {
-        $xmlParser = new \voku\helper\XmlDomParser();
+        $xmlParser = new \Voku\Helper\XmlDomParser();
         $xmlParser->autoRemoveXPathNamespaces();
         $xmlParser->reportXmlErrorsAsException();
 
@@ -245,12 +245,12 @@ final class XmlDomParserTest extends \PHPUnit\Framework\TestCase
 
     public function testIssue63()
     {
-        $dom = (new voku\helper\XmlDomParser())->loadHtml('<Foo> foo bar </Foo>');
+        $dom = (new Voku\Helper\XmlDomParser())->loadHtml('<Foo> foo bar </Foo>');
         static::assertSame(' foo bar ', $dom->findOne('Foo')->innerXml());
-        static::assertInstanceOf(\voku\helper\SimpleXmlDomBlank::class, $dom->findOne('Bar'));
-        static::assertInstanceOf(\voku\helper\SimpleXmlDomBlank::class, $dom->findOne('Bar')->findOne('Bar'));
-        static::assertInstanceOf(\voku\helper\SimpleXmlDomBlank::class, $dom->findOne('Bar')->findOne('Bar')->findOne('Bar'));
-        static::assertInstanceOf(\voku\helper\SimpleXmlDomBlank::class, $dom->findOne('Bar')->findOne('Bar')->findOne('Bar')->findOne('Bar'));
+        static::assertInstanceOf(\Voku\Helper\SimpleXmlDomBlank::class, $dom->findOne('Bar'));
+        static::assertInstanceOf(\Voku\Helper\SimpleXmlDomBlank::class, $dom->findOne('Bar')->findOne('Bar'));
+        static::assertInstanceOf(\Voku\Helper\SimpleXmlDomBlank::class, $dom->findOne('Bar')->findOne('Bar')->findOne('Bar'));
+        static::assertInstanceOf(\Voku\Helper\SimpleXmlDomBlank::class, $dom->findOne('Bar')->findOne('Bar')->findOne('Bar')->findOne('Bar'));
     }
 
     public function testXmlReplace()

--- a/tests/XmlDomParserTest.php
+++ b/tests/XmlDomParserTest.php
@@ -22,7 +22,8 @@ final class XmlDomParserTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testXMLWithoutLoadingDtd() {
+    public function testXMLWithoutLoadingDtd()
+    {
         $cxmlData = '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE cXML SYSTEM "http://xml.cXML.org/schemas/cXML/1.2.024/cXML.dtd"><cXML payloadID="dsfsfsdds" timestamp="2022-12-21T15:35:02+01:00" xml:lang="en-US"><Header><From><Credential domain="NetworkId"><Identity>sdfdfsdf-123</Identity></Credential></From><To><Credential domain="NetworkId"><Identity>fsdfdsfdsfds-321</Identity></Credential></To><Sender><Credential domain="NetworkId"><Identity>fsdfdsfds-1234</Identity></Credential><UserAgent>vdmg: Moelleken, Lars (VDMG-Connect)</UserAgent></Sender></Header><Message><PunchOutOrderMessage><BuyerCookie/><PunchOutOrderMessageHeader operationAllowed="edit"><Total><Money currency="EUR">2.13</Money></Total></PunchOutOrderMessageHeader><ItemIn quantity="1"><ItemID><SupplierPartID>43423342</SupplierPartID></ItemID><ItemDetail><UnitPrice><Money currency="EUR">2.13</Money></UnitPrice><Description xml:lang="de">Stahlblech 10 mm 1200</Description><Classification domain="UNSPSC"/></ItemDetail></ItemIn></PunchOutOrderMessage></Message></cXML>';
 
         $xmlParser = new \Voku\Helper\XmlDomParser();


### PR DESCRIPTION
Fixes: https://github.com/voku/simple_html_dom/issues/94

This repo doesn't work in PHP 8, 8.1 or 8.2 due to the namespaces not being Capitalized.

* Have updated the GitHub workflows up to php 8.2
* Have updated the namespaces.
* Have updated composer.json and removed php 7 as security updates ended in 28 November 2022.
* Have updated readme with new namespaces

Need to update the connecting repos now.

### Linked to Pull Requests

https://github.com/voku/html-compress-twig/pull/5

https://github.com/voku/HtmlMin/pull/85

https://github.com/voku/simple_html_dom/pull/95

https://github.com/voku/simple-cache/pull/30

https://github.com/voku/portable-ascii/pull/87

### Tested on the following

Tested on PHP 8.2 and Laravel 9.1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/simple_html_dom/95)
<!-- Reviewable:end -->
