### PR TITLE
Fix error in parent() method if no parent node

### DIFF
--- a/src/voku/helper/SimpleHtmlDom.php
+++ b/src/voku/helper/SimpleHtmlDom.php
@@ -684,11 +684,15 @@ class SimpleHtmlDom extends AbstractSimpleHtmlDom implements \IteratorAggregate,
     /**
      * Returns the parent of node.
      *
-     * @return SimpleHtmlDomInterface
+     * @return SimpleHtmlDomInterface|null
      */
-    public function parentNode(): SimpleHtmlDomInterface
+    public function parentNode(): ?SimpleHtmlDomInterface
     {
-        return new static($this->node->parentNode);
+        if ($node = $this->node->parentNode) {
+            return new static($node);
+        }
+
+        return null;
     }
 
     /**

--- a/src/voku/helper/SimpleHtmlDomBlank.php
+++ b/src/voku/helper/SimpleHtmlDomBlank.php
@@ -402,9 +402,9 @@ class SimpleHtmlDomBlank extends AbstractSimpleHtmlDom implements \IteratorAggre
     /**
      * Returns the parent of node.
      *
-     * @return SimpleHtmlDomInterface
+     * @return SimpleHtmlDomInterface|null
      */
-    public function parentNode(): SimpleHtmlDomInterface
+    public function parentNode(): ?SimpleHtmlDomInterface
     {
         return new static();
     }

--- a/src/voku/helper/SimpleHtmlDomInterface.php
+++ b/src/voku/helper/SimpleHtmlDomInterface.php
@@ -324,9 +324,9 @@ interface SimpleHtmlDomInterface extends \IteratorAggregate
     /**
      * Returns the parent of node.
      *
-     * @return SimpleHtmlDomInterface
+     * @return SimpleHtmlDomInterface|null
      */
-    public function parentNode(): self;
+    public function parentNode(): ?self;
 
     /**
      * Returns the previous sibling of node.


### PR DESCRIPTION
If you're calling `parent()` or `parentNode()` on an element that has no parent node, the following error is thrown:

```
TypeError: voku\helper\SimpleHtmlDom::__construct(): Argument #1 ($node) must be of type DOMNode, null given
```

This can happen if you load an HTML snippet instead of a whole document.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/simple_html_dom/98)
<!-- Reviewable:end -->
