### PR TITLE
Add text/template type

### DIFF
--- a/src/voku/helper/HtmlDomParser.php
+++ b/src/voku/helper/HtmlDomParser.php
@@ -84,6 +84,7 @@ class HtmlDomParser extends AbstractDomParser
      */
     protected $specialScriptTags = [
         'text/html',
+        'text/template',
         'text/x-custom-template',
         'text/x-handlebars-template',
     ];

--- a/src/voku/helper/HtmlDomParser.php
+++ b/src/voku/helper/HtmlDomParser.php
@@ -75,6 +75,7 @@ class HtmlDomParser extends AbstractDomParser
      * ```php
      * protected $specialScriptTags = [
      *     'text/html',
+     *     'text/template',
      *     'text/x-custom-template',
      *     'text/x-handlebars-template'
      * ]


### PR DESCRIPTION
We experienced issues with closing html tags getting escaped (`<\/a><\/strong>`) in underscore template files used in certain WordPress plugins. 

So I've simply added `text/template` to special script tags to handle underscore template `<script type="text/template">` tags.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/simple_html_dom/104)
<!-- Reviewable:end -->
