### PR TITLE
Adding 'id' to DOMNodes with type string.

### DIFF
--- a/src/voku/helper/AbstractSimpleHtmlDom.php
+++ b/src/voku/helper/AbstractSimpleHtmlDom.php
@@ -23,6 +23,15 @@ abstract class AbstractSimpleHtmlDom
         'innerhtmlkeep'    => 'innerHtmlKeep',
     ];
 
+    /** 
+     * @var string[] 
+     */
+    protected static $stringDomNodes = [
+        'id',
+        'prefix',
+        'content'
+    ];
+
     /**
      * @var \DOMElement|\DOMNode|null
      */
@@ -167,7 +176,7 @@ abstract class AbstractSimpleHtmlDom
             default:
                 if ($this->node && \property_exists($this->node, $nameOrig)) {
                     // INFO: Cannot assign null to property DOMNode::* of type string
-                    if ($nameOrig === 'prefix' || $nameOrig === 'textContent') {
+                    if (in_array($nameOrig, self::$stringDomNodes)) {
                         $value = (string)$value;
                     }
 

--- a/src/voku/helper/AbstractSimpleHtmlDom.php
+++ b/src/voku/helper/AbstractSimpleHtmlDom.php
@@ -23,8 +23,8 @@ abstract class AbstractSimpleHtmlDom
         'innerhtmlkeep'    => 'innerHtmlKeep',
     ];
 
-    /** 
-     * @var string[] 
+    /**
+     * @var string[]
      */
     protected static $stringDomNodes = [
         'id',


### PR DESCRIPTION
Fixing the PHP8.3 type error "Cannot assign null to property DOMElement::$id of type string"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/simple_html_dom/106)
<!-- Reviewable:end -->
