### PR TITLE
Update minimum PHP version to 7.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0",
+        "php": ">=7.1.0",
         "ext-dom": "*",
         "ext-libxml": "*",
         "ext-simplexml": "*",


### PR DESCRIPTION
## Summary

Fixes #111.

`composer.json` declares `"php": ">=7.0.0"` but the codebase uses nullable return types (e.g. `?SimpleHtmlDomInterface` in `SimpleHtmlDom::parentNode()`) which require PHP 7.1+. This means `composer install` succeeds on PHP 7.0 but the code fails at runtime with a parse error.

This PR updates the minimum PHP version from `>=7.0.0` to `>=7.1.0` so Composer correctly rejects PHP 7.0 installations.

## Evidence

```
src/voku/helper/SimpleHtmlDom.php:      public function parentNode(): ?SimpleHtmlDomInterface
src/voku/helper/SimpleHtmlDomBlank.php:  public function parentNode(): ?SimpleHtmlDomInterface
```

Nullable return types (`?Type`) were introduced in PHP 7.1 (RFC: https://wiki.php.net/rfc/nullable_types).

## Test plan

- `composer validate` passes with no errors

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/simple_html_dom/120)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum PHP version requirement to 7.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->