### PR TITLE
Fix Renovate processing for forked repository

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "forkProcessing": "enabled"
+}


### PR DESCRIPTION
Moves the existing Renovate config to the repository root and enables `forkProcessing`.

Why: Mend-hosted Renovate skips forked repositories by default, and `forkProcessing` is only honored from the onboarding config filename (`renovate.json` by default), not `.github/renovate.json`.

This keeps the existing `config:recommended` behavior and changes only what is required to make Renovate actually process this repository.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/simple_html_dom/149)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated processing for Renovate fork updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->